### PR TITLE
fix: freebsd service & logging

### DIFF
--- a/service_freebsd.go
+++ b/service_freebsd.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"text/template"
 )
@@ -77,6 +78,9 @@ func (s *freebsdService) template() *template.Template {
 				return "true"
 			}
 			return "false"
+		},
+		"replaceHyphen": func(s string) string {
+			return strings.ReplaceAll(s, "-", "_")
 		},
 	}
 
@@ -215,11 +219,12 @@ var rcScript = `#!/bin/sh
 
 . /etc/rc.subr
 
-name="{{.Name}}"
-{{.Name}}_env="IS_DAEMON=1"
+name="{{.Name|replaceHyphen}}"
+{{.Name|replaceHyphen}}_env="IS_DAEMON=1"
+{{if .WorkingDirectory}}{{.Name|replaceHyphen}}_chdir="{{.WorkingDirectory}}"{{end}}
 pidfile="/var/run/${name}.pid"
 command="/usr/sbin/daemon"
-daemon_args="-P ${pidfile} -r -t \"${name}: daemon\"{{if .WorkingDirectory}} -c {{.WorkingDirectory}}{{end}}"
+daemon_args="-P ${pidfile} -r -t \"${name}: daemon\" -f"
 command_args="${daemon_args} {{.Path}}{{range .Arguments}} {{.}}{{end}}"
 
 run_rc_command "$1"

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -210,7 +210,7 @@ func (s *systemd) Uninstall() error {
 	if err := os.Remove(cp); err != nil {
 		return err
 	}
-	return nil
+	return s.run("daemon-reload")
 }
 
 func (s *systemd) Logger(errs chan<- error) (Logger, error) {

--- a/service_unix.go
+++ b/service_unix.go
@@ -20,7 +20,7 @@ import (
 const defaultLogDirectory = "/var/log"
 
 func newSysLogger(name string, errs chan<- error) (Logger, error) {
-	w, err := syslog.New(syslog.LOG_INFO, name)
+	w, err := syslog.New(syslog.LOG_DAEMON|syslog.LOG_INFO, name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
1. 修改了 FreeBSD 的服务模板，以正确处理服务名称中带有连字符 `-` 的情况
2. 更改 `syslog` 优先级，以使 FreeBSD 的`/var/log/daemon.log` 可以不经修改配置文件直接获取日志
3. 整合上游修改