### PR TITLE
fix: syslog functionality on macOS 12+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
 module github.com/nezhahq/service
 
-go 1.12
+go 1.18
 
-require golang.org/x/sys v0.20.0
+require (
+	github.com/nezhahq/xsyslog v1.0.0
+	golang.org/x/sys v0.28.0
+)
+
+require github.com/ebitengine/purego v0.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
-golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPMJTiBfWycGh/u3UoO88=
-golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
-golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+github.com/ebitengine/purego v0.8.1 h1:sdRKd6plj7KYW33EH5As6YKfe8m9zbN9JMrOjNVF/BE=
+github.com/ebitengine/purego v0.8.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/nezhahq/xsyslog v1.0.0 h1:fSSDxaMy7eEWdTB5L2yp47GOctOM/gItfPsF1freZBc=
+github.com/nezhahq/xsyslog v1.0.0/go.mod h1:wRJ6n/bly5i71/ZWhnoA39v0rFvr3Q1PSlIlExbX3fk=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/service_unix.go
+++ b/service_unix.go
@@ -15,12 +15,14 @@ import (
 	"log/syslog"
 	"os/exec"
 	"syscall"
+
+	"github.com/nezhahq/xsyslog"
 )
 
 const defaultLogDirectory = "/var/log"
 
 func newSysLogger(name string, errs chan<- error) (Logger, error) {
-	w, err := syslog.New(syslog.LOG_DAEMON|syslog.LOG_INFO, name)
+	w, err := xsyslog.New(syslog.LOG_DAEMON|syslog.LOG_INFO, name)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +30,7 @@ func newSysLogger(name string, errs chan<- error) (Logger, error) {
 }
 
 type sysLogger struct {
-	*syslog.Writer
+	*xsyslog.Writer
 	errs chan<- error
 }
 


### PR DESCRIPTION
`github.com/nezhahq/xsyslog` 通过调用 `syslog(3)` 来实现写入 syslog 功能，绕开了 macOS 12+ syslog 不在监听 socket 的问题